### PR TITLE
Added optional support for duplicate keys

### DIFF
--- a/src/Seld/JsonLint/JsonParser.php
+++ b/src/Seld/JsonLint/JsonParser.php
@@ -29,8 +29,8 @@ use stdClass;
 class JsonParser
 {
     const DETECT_KEY_CONFLICTS = 1;
-	const ALLOW_DUPLICATE_KEYS = 2;
-		
+    const ALLOW_DUPLICATE_KEYS = 2;
+        
     private $flags;
     private $stack;
     private $vstack; // semantic value stack
@@ -355,21 +355,19 @@ class JsonParser
             break;
         case 17:
             $yyval->token = $tokens[$len-2];
-			$key = $tokens[$len][0];
+            $key = $tokens[$len][0];
             if (($this->flags & self::DETECT_KEY_CONFLICTS) && isset($tokens[$len-2]->{$tokens[$len][0]})) {
                 $errStr = 'Parse error on line ' . ($yylineno+1) . ":\n";
                 $errStr .= $this->lexer->showPosition() . "\n";
                 $errStr .= "Duplicate key: ".$tokens[$len][0];
                 throw new ParsingException($errStr);
             }
-			elseif (($this->flags & self::ALLOW_DUPLICATE_KEYS) && isset($tokens[$len-2]->{$tokens[$len][0]})) {
-				$duplicateCount = 1;	
-				do
-				{
-					$duplicateKey = $key . '.' . $duplicateCount++;
-					
-				} while (isset($tokens[$len-2]->$duplicateKey));
-				$key = $duplicateKey;
+            elseif (($this->flags & self::ALLOW_DUPLICATE_KEYS) && isset($tokens[$len-2]->{$tokens[$len][0]})) {
+                $duplicateCount = 1;    
+                do {
+                    $duplicateKey = $key . '.' . $duplicateCount++;
+                } while (isset($tokens[$len-2]->$duplicateKey));
+                $key = $duplicateKey;
             }
             $tokens[$len-2]->$key = $tokens[$len][1];
             break;

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -70,16 +70,16 @@ class JsonParserTest extends PHPUnit_Framework_TestCase
             $this->assertContains('Duplicate key: a', $e->getMessage());
         }
     }
-	public function testDuplicateKeys()
+    public function testDuplicateKeys()
     {
         $parser = new JsonParser();
 
-		$result = $parser->parse('{"a":"b", "a":"c", "a":"d"}', JsonParser::ALLOW_DUPLICATE_KEYS);
-		$this->assertThat($result,
-			$this->logicalAnd(
-				$this->arrayHasKey('a'),
-				$this->arrayHasKey('a.1'),
-				$this->arrayHasKey('a.2')
-			));
+        $result = $parser->parse('{"a":"b", "a":"c", "a":"d"}', JsonParser::ALLOW_DUPLICATE_KEYS);
+        $this->assertThat($result,
+            $this->logicalAnd(
+                $this->arrayHasKey('a'),
+                $this->arrayHasKey('a.1'),
+                $this->arrayHasKey('a.2')
+            ));
     }
 }


### PR DESCRIPTION
Added support for duplicate keys via ALLOW_DUPLICATE_KEYS constant. Will take something like:

``` javascript
{
    "a" : 1234,
    "a" : 4567,
    "a" : 8910
}

and convert to

{
    "a" : 1234,
    "a.1" : 4567,
    "a.2" : 8910
}
```

In this way, if someone has a JSON file with keys that are acted like verbs, for example, for using JSON as configuration files, where you may have multiple action blocks. Rather than wrap blocks in extra brackets, or be forced to add unique charachters to verb.
