### PR TITLE
Updated README to highlight the use of getMessage() to see the parse errors

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -6,17 +6,28 @@ JSON Lint
 Usage
 -----
 
-    use Seld\JsonLint\JsonParser;
+```php
+use Seld\JsonLint\JsonParser;
 
-    $parser = new JsonParser();
+$parser = new JsonParser();
     
-    // returns null if it's valid json, or a ParsingException object. Call
-    // ->getDetails() on the exception to get more info.
-    $parser->lint($json);
+// returns null if it's valid json, or a ParsingException object.
+$parser->lint($json);
 
-    // returns parsed json, like json_decode() does, but slower, throws
-    // exceptions on failure.
-    $parser->parse($json);
+// Call getMessage() on the exception object to get
+// a well formatted error message error like this
+
+// Parse error on line 2:
+// ... "key": "value"    "numbers": [1, 2, 3]
+// ----------------------^
+// Expected one of: 'EOF', '}', ':', ',', ']'
+
+// Call getDetails() on the exception to get more info.
+
+// returns parsed json, like json_decode() does, but slower, throws
+// exceptions on failure.
+$parser->parse($json);
+```
 
 Installation
 ------------


### PR DESCRIPTION
The README does not mention the use of getMessage() to get the formatted error message, which I think is one of the awesome use cases for this library.

Also added the php tag to the code in the README to add syntax highlighting
