### PR TITLE
Fixed the code showing the position of the lexer

### DIFF
--- a/src/Seld/JsonLint/Lexer.php
+++ b/src/Seld/JsonLint/Lexer.php
@@ -81,7 +81,7 @@ class Lexer
     public function showPosition()
     {
         $pre = str_replace("\n", '', $this->getPastInput());
-        $c = str_repeat('-', strlen($pre) - 1); // new Array(pre.length + 1).join("-");
+        $c = str_repeat('-', strlen($pre)); // new Array(pre.length + 1).join("-");
 
         return $pre . str_replace("\n", '', $this->getUpcomingInput()) . "\n" . $c . "^";
     }


### PR DESCRIPTION
The PHP code had an off-by-1 error compared to the ported JS code, causing a str_repeat with a -1 length when the previous line is empty.
Fixes https://github.com/composer/composer/issues/3151
