### PR TITLE
Build against PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,15 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
+
+# run build against php 7.0 but allow them to fail
+# http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7.0
 
 before_script:
   - composer update


### PR DESCRIPTION
Composer fails from an exception of this library on PHP 7 so I enabled testing against PHP7 to see if unit tests pass.
https://travis-ci.org/yiisoft/yii2/jobs/52251656#L1496