### PR TITLE
Switch to the docker-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.3
   - 5.4


### PR DESCRIPTION
the new infrastructure starts faster, and we don't rely on sudo in the build so we can use it