### PR TITLE
Add possibility for flags to JsonParser::lint()

### DIFF
--- a/src/Seld/JsonLint/JsonParser.php
+++ b/src/Seld/JsonLint/JsonParser.php
@@ -117,12 +117,13 @@ class JsonParser
 
     /**
      * @param  string                $input JSON string
+     * @param  int                   $flags Bitmask of parse/lint options (see constants of this class)
      * @return null|ParsingException null if no error is found, a ParsingException containing all details otherwise
      */
-    public function lint($input)
+    public function lint($input, $flags = 0)
     {
         try {
-            $this->parse($input);
+            $this->parse($input, $flags);
         } catch (ParsingException $e) {
             return $e;
         }
@@ -130,6 +131,7 @@ class JsonParser
 
     /**
      * @param  string           $input JSON string
+     * @param  int              $flags Bitmask of parse/lint options (see constants of this class)
      * @return mixed
      * @throws ParsingException
      */


### PR DESCRIPTION
Instead of requiring to use parse() instead of lint, just because the user wants
to pass flags (like DETECT_KEY_CONFLICTS) to the "linter", the JsonParser::lint()
function now takes a flags bitmask, too (like parse()).

This also fixes the docblock of parse(), which as of now had not documented
the second argument.