### PR TITLE
Fix unicode characters handling

### DIFF
--- a/src/Seld/JsonLint/JsonParser.php
+++ b/src/Seld/JsonLint/JsonParser.php
@@ -450,6 +450,10 @@ class JsonParser
 
     private function stringInterpolation($match)
     {
+        if (strpos($match[0], '\u') === 0) {
+            return json_decode('"'.$match[0].'"');
+        }
+
         switch ($match[0]) {
         case '\\\\':
             return '\\';

--- a/src/Seld/JsonLint/JsonParser.php
+++ b/src/Seld/JsonLint/JsonParser.php
@@ -450,10 +450,6 @@ class JsonParser
 
     private function stringInterpolation($match)
     {
-        if (strpos($match[0], '\u') === 0) {
-            return json_decode('"'.$match[0].'"');
-        }
-
         switch ($match[0]) {
         case '\\\\':
             return '\\';
@@ -472,6 +468,9 @@ class JsonParser
         case '\/':
             return "/";
         default:
+            if (strpos($match[0], '\u') === 0) {
+                return json_decode('"'.$match[0].'"');
+            }
             return html_entity_decode('&#x'.ltrim(substr($match[0], 2), '0').';', 0, 'UTF-8');
         }
     }

--- a/src/Seld/JsonLint/JsonParser.php
+++ b/src/Seld/JsonLint/JsonParser.php
@@ -468,10 +468,7 @@ class JsonParser
         case '\/':
             return "/";
         default:
-            if (strpos($match[0], '\u') === 0) {
-                return json_decode('"'.$match[0].'"');
-            }
-            return html_entity_decode('&#x'.ltrim(substr($match[0], 2), '0').';', 0, 'UTF-8');
+            return html_entity_decode('&#x'.ltrim(substr($match[0], 2), '0').';', ENT_QUOTES, 'UTF-8');
         }
     }
 

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -35,6 +35,9 @@ class JsonParserTest extends TestCase
         '{"a":"b", "b":"c"}',
         '0',
         '""',
+        '"\u0022"',
+        '"Argument \u0022input\u0022 has an invalid value: ..."',
+        '"👻"',
     );
 
     /**

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -38,6 +38,7 @@ class JsonParserTest extends TestCase
         '"\u0022"',
         '"Argument \u0022input\u0022 has an invalid value: ..."',
         '"👻"',
+        '"\u1f47d"',
     );
 
     /**


### PR DESCRIPTION
Closes #59

I'm not an expert at this so I'm not sure this is the best way to handle this case to be honest. It's also a bit weird to use `json_decode` there but I've picked that solution as alternatives suggested the use of `mb_string` and I preferred to avoid a dependency on an extension at this point.