### PR TITLE
Use fully-qualified calls for compiler optimized functions

### DIFF
--- a/src/Seld/JsonLint/JsonParser.php
+++ b/src/Seld/JsonLint/JsonParser.php
@@ -173,7 +173,7 @@ class JsonParser
 
         while (true) {
             // retrieve state number from top of stack
-            $state = $this->stack[count($this->stack)-1];
+            $state = $this->stack[\count($this->stack)-1];
 
             // use default actions if available
             if (isset($this->defaultActions[$state])) {
@@ -198,7 +198,7 @@ class JsonParser
                     }
 
                     $message = null;
-                    if (in_array("'STRING'", $expected) && in_array(substr($this->lexer->match, 0, 1), array('"', "'"))) {
+                    if (\in_array("'STRING'", $expected) && \in_array(substr($this->lexer->match, 0, 1), array('"', "'"))) {
                         $message = "Invalid string";
                         if ("'" === substr($this->lexer->match, 0, 1)) {
                             $message .= ", it appears you used single quotes instead of double quotes";
@@ -214,7 +214,7 @@ class JsonParser
                     if ($message) {
                         $errStr .= $message;
                     } else {
-                        $errStr .= (count($expected) > 1) ? "Expected one of: " : "Expected: ";
+                        $errStr .= (\count($expected) > 1) ? "Expected one of: " : "Expected: ";
                         $errStr .= implode(', ', $expected);
                     }
 
@@ -248,25 +248,25 @@ class JsonParser
                 // try to recover from error
                 while (true) {
                     // check for error recovery rule in this state
-                    if (array_key_exists($TERROR, $this->table[$state])) {
+                    if (\array_key_exists($TERROR, $this->table[$state])) {
                         break;
                     }
                     if ($state == 0) {
                         throw new ParsingException($errStr ?: 'Parsing halted.');
                     }
                     $this->popStack(1);
-                    $state = $this->stack[count($this->stack)-1];
+                    $state = $this->stack[\count($this->stack)-1];
                 }
 
                 $preErrorSymbol = $symbol; // save the lookahead token
                 $symbol = $TERROR;         // insert generic error symbol as new lookahead
-                $state = $this->stack[count($this->stack)-1];
+                $state = $this->stack[\count($this->stack)-1];
                 $action = isset($this->table[$state][$TERROR]) ? $this->table[$state][$TERROR] : false;
                 $recovering = 3; // allow 3 real symbols to be shifted before reporting a new error
             }
 
             // this shouldn't happen, unless resolve defaults are off
-            if (is_array($action[0]) && count($action) > 1) {
+            if (\is_array($action[0]) && \count($action) > 1) {
                 throw new ParsingException('Parse Error: multiple actions possible at state: ' . $state . ', token: ' . $symbol);
             }
 
@@ -295,13 +295,13 @@ class JsonParser
                     $len = $this->productions_[$action[1]][1];
 
                     // perform semantic action
-                    $yyval->token = $this->vstack[count($this->vstack) - $len]; // default to $$ = $1
+                    $yyval->token = $this->vstack[\count($this->vstack) - $len]; // default to $$ = $1
                     // default location, uses first token for firsts, last for lasts
                     $yyval->store = array( // _$ = store
-                        'first_line' => $this->lstack[count($this->lstack) - ($len ?: 1)]['first_line'],
-                        'last_line' => $this->lstack[count($this->lstack) - 1]['last_line'],
-                        'first_column' => $this->lstack[count($this->lstack) - ($len ?: 1)]['first_column'],
-                        'last_column' => $this->lstack[count($this->lstack) - 1]['last_column'],
+                        'first_line' => $this->lstack[\count($this->lstack) - ($len ?: 1)]['first_line'],
+                        'last_line' => $this->lstack[\count($this->lstack) - 1]['last_line'],
+                        'first_column' => $this->lstack[\count($this->lstack) - ($len ?: 1)]['first_column'],
+                        'last_column' => $this->lstack[\count($this->lstack) - 1]['last_column'],
                     );
                     $r = $this->performAction($yyval, $yytext, $yyleng, $yylineno, $action[1], $this->vstack, $this->lstack);
 
@@ -316,7 +316,7 @@ class JsonParser
                     $this->stack[] = $this->productions_[$action[1]][0];    // push nonterminal (reduce)
                     $this->vstack[] = $yyval->token;
                     $this->lstack[] = $yyval->store;
-                    $newState = $this->table[$this->stack[count($this->stack)-2]][$this->stack[count($this->stack)-1]];
+                    $newState = $this->table[$this->stack[\count($this->stack)-2]][$this->stack[\count($this->stack)-1]];
                     $this->stack[] = $newState;
                     break;
 
@@ -340,7 +340,7 @@ class JsonParser
     private function performAction(stdClass $yyval, $yytext, $yyleng, $yylineno, $yystate, &$tokens)
     {
         // $0 = $len
-        $len = count($tokens) - 1;
+        $len = \count($tokens) - 1;
         switch ($yystate) {
         case 1:
             $yytext = preg_replace_callback('{(?:\\\\["bfnrt/\\\\]|\\\\u[a-fA-F0-9]{4})}', array($this, 'stringInterpolation'), $yytext);
@@ -348,9 +348,9 @@ class JsonParser
             break;
         case 2:
             if (strpos($yytext, 'e') !== false || strpos($yytext, 'E') !== false) {
-                $yyval->token = floatval($yytext);
+                $yyval->token = \floatval($yytext);
             } else {
-                $yyval->token = strpos($yytext, '.') === false ? intval($yytext) : floatval($yytext);
+                $yyval->token = strpos($yytext, '.') === false ? \intval($yytext) : \floatval($yytext);
             }
             break;
         case 3:
@@ -456,9 +456,9 @@ class JsonParser
         case '\"':
             return '"';
         case '\b':
-            return chr(8);
+            return \chr(8);
         case '\f':
-            return chr(12);
+            return \chr(12);
         case '\n':
             return "\n";
         case '\r':
@@ -474,9 +474,9 @@ class JsonParser
 
     private function popStack($n)
     {
-        $this->stack = array_slice($this->stack, 0, - (2 * $n));
-        $this->vstack = array_slice($this->vstack, 0, - $n);
-        $this->lstack = array_slice($this->lstack, 0, - $n);
+        $this->stack = \array_slice($this->stack, 0, - (2 * $n));
+        $this->vstack = \array_slice($this->vstack, 0, - $n);
+        $this->lstack = \array_slice($this->lstack, 0, - $n);
     }
 
     private function lex()

--- a/src/Seld/JsonLint/Lexer.php
+++ b/src/Seld/JsonLint/Lexer.php
@@ -81,26 +81,26 @@ class Lexer
     public function showPosition()
     {
         $pre = str_replace("\n", '', $this->getPastInput());
-        $c = str_repeat('-', max(0, strlen($pre) - 1)); // new Array(pre.length + 1).join("-");
+        $c = str_repeat('-', max(0, \strlen($pre) - 1)); // new Array(pre.length + 1).join("-");
 
         return $pre . str_replace("\n", '', $this->getUpcomingInput()) . "\n" . $c . "^";
     }
 
     public function getPastInput()
     {
-        $past = substr($this->matched, 0, strlen($this->matched) - strlen($this->match));
+        $past = substr($this->matched, 0, \strlen($this->matched) - \strlen($this->match));
 
-        return (strlen($past) > 20 ? '...' : '') . substr($past, -20);
+        return (\strlen($past) > 20 ? '...' : '') . substr($past, -20);
     }
 
     public function getUpcomingInput()
     {
         $next = $this->match;
-        if (strlen($next) < 20) {
-            $next .= substr($this->input, 0, 20 - strlen($next));
+        if (\strlen($next) < 20) {
+            $next .= substr($this->input, 0, 20 - \strlen($next));
         }
 
-        return substr($next, 0, 20) . (strlen($next) > 20 ? '...' : '');
+        return substr($next, 0, 20) . (\strlen($next) > 20 ? '...' : '');
     }
 
     protected function parseError($str, $hash)
@@ -128,29 +128,29 @@ class Lexer
         }
 
         $rules = $this->getCurrentRules();
-        $rulesLen = count($rules);
+        $rulesLen = \count($rules);
 
         for ($i=0; $i < $rulesLen; $i++) {
             if (preg_match($this->rules[$rules[$i]], $this->input, $match)) {
                 preg_match_all('/\n.*/', $match[0], $lines);
                 $lines = $lines[0];
                 if ($lines) {
-                    $this->yylineno += count($lines);
+                    $this->yylineno += \count($lines);
                 }
 
                 $this->yylloc = array(
                     'first_line' => $this->yylloc['last_line'],
                     'last_line' => $this->yylineno+1,
                     'first_column' => $this->yylloc['last_column'],
-                    'last_column' => $lines ? strlen($lines[count($lines) - 1]) - 1 : $this->yylloc['last_column'] + strlen($match[0]),
+                    'last_column' => $lines ? \strlen($lines[\count($lines) - 1]) - 1 : $this->yylloc['last_column'] + \strlen($match[0]),
                 );
                 $this->yytext .= $match[0];
                 $this->match .= $match[0];
-                $this->yyleng = strlen($this->yytext);
+                $this->yyleng = \strlen($this->yytext);
                 $this->more = false;
-                $this->input = substr($this->input, strlen($match[0]));
+                $this->input = substr($this->input, \strlen($match[0]));
                 $this->matched .= $match[0];
-                $token = $this->performAction($rules[$i], $this->conditionStack[count($this->conditionStack)-1]);
+                $token = $this->performAction($rules[$i], $this->conditionStack[\count($this->conditionStack)-1]);
                 if ($token) {
                     return $token;
                 }
@@ -175,7 +175,7 @@ class Lexer
 
     private function getCurrentRules()
     {
-        return $this->conditions[$this->conditionStack[count($this->conditionStack)-1]]['rules'];
+        return $this->conditions[$this->conditionStack[\count($this->conditionStack)-1]]['rules'];
     }
 
     private function performAction($avoiding_name_collisions, $YY_START)


### PR DESCRIPTION
This patch is generated automatically by PHP-CS-Fixer:

```bash
php-cs-fixer fix src --rules='{"native_function_invocation": {"scope":"namespaced","include":["@compiler_optimized"]}}' --allow-risky=yes
```

This gives a major performance boost, for free, thanks to PHP optimizations:

![image](https://user-images.githubusercontent.com/439401/80636344-9b47ff80-8a5d-11ea-8eb2-387be212f486.png)

Note that depending on the input file, the win was not that big, but even a 10% perf increase for free is good.
