### PR TITLE
use @phpstan- prefix instead of @psalm-

### DIFF
--- a/src/Seld/JsonLint/DuplicateKeyException.php
+++ b/src/Seld/JsonLint/DuplicateKeyException.php
@@ -16,7 +16,7 @@ class DuplicateKeyException extends ParsingException
     /**
      * @param string $message
      * @param string $key
-     * @psalm-param array{text?: string, token?: string, line?: int, loc?: array{first_line: int, first_column: int, last_line: int, last_column: int}, expected?: string[]} $details
+     * @phpstan-param array{text?: string, token?: string, line?: int, loc?: array{first_line: int, first_column: int, last_line: int, last_column: int}, expected?: string[]} $details
      */
     public function __construct($message, $key, array $details = array())
     {
@@ -30,7 +30,7 @@ class DuplicateKeyException extends ParsingException
     }
 
     /**
-     * @psalm-return array{text?: string, token?: string, line?: int, loc?: array{first_line: int, first_column: int, last_line: int, last_column: int}, expected?: string[], key: string}
+     * @phpstan-return array{text?: string, token?: string, line?: int, loc?: array{first_line: int, first_column: int, last_line: int, last_column: int}, expected?: string[], key: string}
      */
     public function getDetails()
     {

--- a/src/Seld/JsonLint/ParsingException.php
+++ b/src/Seld/JsonLint/ParsingException.php
@@ -17,7 +17,7 @@ class ParsingException extends \Exception
 
     /**
      * @param string $message
-     * @psalm-param array{text?: string, token?: string, line?: int, loc?: array{first_line: int, first_column: int, last_line: int, last_column: int}, expected?: string[]} $details
+     * @phpstan-param array{text?: string, token?: string, line?: int, loc?: array{first_line: int, first_column: int, last_line: int, last_column: int}, expected?: string[]} $details
      */
     public function __construct($message, $details = array())
     {
@@ -26,7 +26,7 @@ class ParsingException extends \Exception
     }
 
     /**
-     * @psalm-return array{text?: string, token?: string, line?: int, loc?: array{first_line: int, first_column: int, last_line: int, last_column: int}, expected?: string[]}
+     * @phpstan-return array{text?: string, token?: string, line?: int, loc?: array{first_line: int, first_column: int, last_line: int, last_column: int}, expected?: string[]}
      */
     public function getDetails()
     {


### PR DESCRIPTION
refs https://github.com/Seldaek/jsonlint/issues/73

> Also, if you're using just PHPStan, I'd recommend prefixing PHPDocs with @phpstan- instead of @psalm- because PHPStan ignores any PHPDoc parsing issues in @psalm- prefixed tags because of forward compatibility.
