### PR TITLE
Fix usage line in help page to be path to program

### DIFF
--- a/bin/jsonlint
+++ b/bin/jsonlint
@@ -37,7 +37,7 @@ if (isset($_SERVER['argc']) && $_SERVER['argc'] > 1) {
             $quiet = true;
         } else {
             if ($arg == '-h' || $arg == '--help') {
-                showUsage();
+                showUsage($_SERVER['argv'][0]);
             } else {
                 $files[] = $arg;
             }
@@ -106,9 +106,9 @@ function lintFile($file, $quiet = false)
 }
 
 // usage text function
-function showUsage()
+function showUsage($programPath)
 {
-    echo 'Usage: jsonlint file [options]'.PHP_EOL;
+    echo 'Usage: '.$programPath.' file [options]'.PHP_EOL;
     echo PHP_EOL;
     echo 'Options:'.PHP_EOL;
     echo '  -q, --quiet     Cause jsonlint to be quiet when no errors are found'.PHP_EOL;


### PR DESCRIPTION
This commit adjusts the help screen to display the path to this program rather
than the name. Normally, this is the same as the binary, but in some cases it
can be different.

Conventionally, the path is shown. For instance, GNU cat does the following:

    $ cat --help
    Usage: cat [OPTION]... [FILE]...

Which is not the name of the program, but the path:

    $ ln -s /usr/bin/cat dog
    $ ./dog --help
    Usage: ./dog [OPTION]... [FILE]...
    Concatenate FILE(s) to standard output.