### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,26 @@ matrix:
       dist: bionic
     - php: nightly
       dist: bionic
+    # Adding jobs for ppc64le
+    - php: 5.6
+      arch: ppc64le
+      dist: xenial
+    - php: 7.0
+      arch: ppc64le
+      dist: xenial
+    - php: 7.1
+      arch: ppc64le
+      dist: bionic
+    - php: 7.2
+      arch: ppc64le
+      dist: bionic
+    - php: 7.4
+      arch: ppc64le
+      dist: bionic
+    - php: nightly
+      arch: ppc64le
+      dist: bionic
+
   fast_finish: true
 
 install:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The Travis-CI build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/jsonlint/builds/198717338

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj