### PR TITLE
Lexer: fix handling of cut off json where string don't terminate

### DIFF
--- a/src/Seld/JsonLint/Lexer.php
+++ b/src/Seld/JsonLint/Lexer.php
@@ -112,7 +112,11 @@ class Lexer
         $next = $this->match;
         if (substr($next, 0, 1) === '"' && substr_count($next, '"') === 1) {
             $len = \strlen($this->input);
-            $strEnd = min(strpos($this->input, '"', $this->offset + 1) ?: $len, strpos($this->input, "\n", $this->offset + 1) ?: $len);
+            if ($len === $this->offset) {
+                $strEnd = $len;
+            } else {
+                $strEnd = min(strpos($this->input, '"', $this->offset + 1) ?: $len, strpos($this->input, "\n", $this->offset + 1) ?: $len);
+            }
             $next .= substr($this->input, $this->offset, $strEnd - $this->offset);
         } elseif (\strlen($next) < 20) {
             $next .= substr($this->input, $this->offset, 20 - \strlen($next));

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -269,4 +269,15 @@ bar"}');
         $json = '{"k":"' . str_repeat("a\\n",10000) . '"}';
         $this->assertEquals(json_decode($json), $parser->parse($json));
     }
+
+    public function testParseNoneTerminatingString()
+    {
+        $parser = new JsonParser();
+
+        try {
+            $this->assertEquals('', $parser->parse('{"'));
+        } catch (ParsingException $e) {
+            $this->assertContains('Invalid string, it appears you forgot to terminate a string', $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Resolves `ValueError: "strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)" at src/Seld/JsonLint/Lexer.php line 115`