### PR TITLE
Added allow comments flag

### DIFF
--- a/src/Seld/JsonLint/JsonParser.php
+++ b/src/Seld/JsonLint/JsonParser.php
@@ -30,6 +30,7 @@ class JsonParser
     const DETECT_KEY_CONFLICTS = 1;
     const ALLOW_DUPLICATE_KEYS = 2;
     const PARSE_TO_ASSOC = 4;
+    const ALLOW_COMMENTS = 8;
 
     /** @var Lexer */
     private $lexer;
@@ -214,7 +215,7 @@ class JsonParser
         /** @var int<0,3> */
         $recovering = 0;
 
-        $this->lexer = new Lexer();
+        $this->lexer = new Lexer($flags);
         $this->lexer->setInput($input);
 
         $yyloc = $this->lexer->yylloc;

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -284,4 +284,41 @@ bar"}');
             $this->assertContains('Invalid string, it appears you forgot to terminate a string', $e->getMessage());
         }
     }
+
+    /**
+     * @dataProvider provideStringsWithComments
+     * @param string $withComment
+     * @param string $valid
+     */
+    public function testParsesJsonStringWithComments($withComment, $valid)
+    {
+        $parser = new JsonParser();
+        $this->assertNotNull($parser->lint($withComment));
+        $this->assertNull($parser->lint($withComment, JsonParser::ALLOW_COMMENTS));
+
+        $this->assertEquals(json_decode($valid), $parser->parse($withComment, JsonParser::ALLOW_COMMENTS));
+    }
+
+    public function provideStringsWithComments()
+    {
+        $json = array(
+            '["a", "sdfsd"]//test' => '["a", "sdfsd"]',
+            '[/*"a",*/ "sdfsd"]//' => '["sdfsd"]',
+            '["a", "sdf//sd"]/**/' => '["a", "sdf//sd"]',
+            '/**/{/*"":*/"g":"foo"}' => '{"g":"foo"}',
+            '{"a":"b"}//, "b":"c"}' => '{"a":"b"}',
+        );
+
+        $strings = array();
+        foreach ($json as $withComment => $valid) {
+            $strings[] = array($withComment, $valid);
+        }
+
+        $strings[] = array(
+            file_get_contents(dirname(__FILE__) .'/with-comments.json'),
+            file_get_contents(dirname(__FILE__) .'/without-comments.json')
+        );
+
+        return $strings;
+    }
 }

--- a/tests/with-comments.json
+++ b/tests/with-comments.json
@@ -1,0 +1,17 @@
+{
+    //tr "test"\naabm/
+    "name": "vendor/com2",
+    "autoload": {
+        "psr-4": {
+            "Vendor\\Com1\\": "src/"
+        }
+    },
+    "repositories": [
+        {"type": "composer", "url": "https://example.com/mirror/magento/"}/*,
+        {"packagist": false}*/
+    ],//
+    "require": {
+        "firebase/php-jwt": "^6.0"//, /*
+      // "phpunit/phpunit": "^8.0"
+    }
+}//

--- a/tests/without-comments.json
+++ b/tests/without-comments.json
@@ -1,0 +1,14 @@
+{
+    "name": "vendor/com2",
+    "autoload": {
+        "psr-4": {
+            "Vendor\\Com1\\": "src/"
+        }
+    },
+    "repositories": [
+        {"type": "composer", "url": "https://example.com/mirror/magento/"}
+    ],
+    "require": {
+        "firebase/php-jwt": "^6.0"
+    }
+}


### PR DESCRIPTION
Fixes #58. 

In this PR has been added flag `ALLOW_COMMENTS` to allow ignore the comments.

Example usage:

```php
$parser = new JsonParser();
$data = $parser->parse($content, JsonParser::ALLOW_COMMENTS);
```

Without this flag, JSON validation works as before, so there are not BC break here.