### PR TITLE
Allow quiet mode when parsing from stdin.

### DIFF
--- a/bin/jsonlint
+++ b/bin/jsonlint
@@ -58,7 +58,7 @@ if (!empty($files)) {
 } else {
     //stdin linting
     if ($contents = file_get_contents('php://stdin')) {
-        lint($contents);
+        lint($contents, $quiet);
     } else {
         fwrite(STDERR, 'No file name or json input given' . PHP_EOL);
         exit(1);


### PR DESCRIPTION
Quiet mode (introduced in https://github.com/Seldaek/jsonlint/pull/17) doesn't work when parsing from stdin.

For example, running the command `echo '{}' | jsonlint --quiet` still produces the output `Valid JSON (stdin)`.

This PR fixes it.